### PR TITLE
fix: Refresh UI on difficulty select and add tests

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,7 +13,8 @@ let difficulty = 'MEDIUM'; // EASY, MEDIUM, HARD
 window.game = {
     get gameStarted() { return gameStarted; },
     get gameOver() { return gameOver; },
-    get winner() { return winner; }
+    get winner() { return winner; },
+    get difficulty() { return difficulty; }
 };
 
 // Game objects
@@ -286,9 +287,9 @@ window.addEventListener('keydown', (e) => {
     if (e.key === 'ArrowDown') keys.ArrowDown = true;
 
     if (!gameStarted) {
-        if (e.key === '1') difficulty = 'EASY';
-        if (e.key === '2') difficulty = 'MEDIUM';
-        if (e.key === '3') difficulty = 'HARD';
+        if (e.key === '1') { difficulty = 'EASY'; render(); }
+        if (e.key === '2') { difficulty = 'MEDIUM'; render(); }
+        if (e.key === '3') { difficulty = 'HARD'; render(); }
 
         if (e.key === ' ' || e.code === 'Space') {
             gameStarted = true;

--- a/tests/game.spec.js
+++ b/tests/game.spec.js
@@ -30,3 +30,26 @@ test('game starts on spacebar', async ({ page }) => {
         timeout: 5000,
     }).toBe(true);
 });
+
+test('difficulty selection works', async ({ page }) => {
+    await page.goto('/');
+
+    // Check default difficulty
+    let difficulty = await page.evaluate(() => window.game.difficulty);
+    expect(difficulty).toBe('MEDIUM');
+
+    // Select Easy
+    await page.keyboard.press('1');
+    difficulty = await page.evaluate(() => window.game.difficulty);
+    expect(difficulty).toBe('EASY');
+
+    // Select Hard
+    await page.keyboard.press('3');
+    difficulty = await page.evaluate(() => window.game.difficulty);
+    expect(difficulty).toBe('HARD');
+
+    // Select Medium
+    await page.keyboard.press('2');
+    difficulty = await page.evaluate(() => window.game.difficulty);
+    expect(difficulty).toBe('MEDIUM');
+});


### PR DESCRIPTION
Fixes a bug where the difficulty selection on the start screen was not visually updating until the game started. Added a manual 'render()' call on keypress. Also added automated Playwright tests to cover this scenario.